### PR TITLE
Update MMM-BMWConnected.js

### DIFF
--- a/MMM-BMWConnected.js
+++ b/MMM-BMWConnected.js
@@ -185,10 +185,10 @@ Module.register('MMM-BMWConnected', {
     }
     
     var sunroof = "sunroof : ";
-    if (info.sunroof === "CLOSED"){
-        sunroof = "closed";
-    }else{
+    if (info.sunroof === "OPEN"){
         sunroof = "open";
+    }else{
+        sunroof = "closed";
     }  
 
     var boot = "";


### PR DESCRIPTION
Switched the if values because in my case without a sunroof the alert appears, that the sunroof is open. The following values can the sunroof (+hatch, trunk, doors, windows) variable have: CLOSED, OPEN, OPEN_TILT, INTERMEDIATE, INVALID. Might make sense to change the other if clauses too, but I think the sunroof is special based on being optional.

Source of the values: https://github.com/bimmerconnected/bimmer_connected/blob/dev/bimmer_connected/vehicle_status.py